### PR TITLE
Allow objectMode to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,15 @@ var copy = function copy(o) {
 };
 
 var Dissolve = module.exports = function Dissolve(options) {
-  if (!(this instanceof Dissolve)) { return new Dissolve(); }
+  if (!(this instanceof Dissolve)) { return new Dissolve(options); }
 
   if (!options) {
     options = {};
   }
 
-  options.objectMode = true;
+  if (!options.hasOwnProperty('objectMode')) {
+    options.objectMode = true;
+  }
 
   stream.Transform.call(this, options);
 


### PR DESCRIPTION
This allows me to do something like:

```javascript
Dissolve({'objectMode':false}).loop(function (end) {
  this.uint32le('len')
  .buffer('data', 'len')
  .tap(function () {
    this.push(this.vars.data)
  })
})
```

I can then `pipe()` that into some other stream.